### PR TITLE
avro fixes for OCP

### DIFF
--- a/itg-tests/ContainersPython/addAvroContainer.sh
+++ b/itg-tests/ContainersPython/addAvroContainer.sh
@@ -47,6 +47,7 @@ if [ "OCP" == "${kcenv}" ]; then
     FINAL_SCHEMA_REGISTRY_URL="https://token:${KAFKA_APIKEY}@${END_SCHEMA_REGISTRY_URL}" 
 else
     FINAL_SCHEMA_REGISTRY_URL=${SCHEMA_REGISTRY_URL}
+    attach_to_network="--network=docker_default"
 fi
 
 
@@ -61,7 +62,7 @@ docker run  -e KAFKA_BROKERS=$KAFKA_BROKERS \
             -e DATA_SCHEMAS="/refarch-kc/data_schemas" \
             ${add_cert_to_container_command} \
             -v ${MAIN_DIR}:/refarch-kc \
-            --network=docker_default \
+            ${attach_to_network} \
             --rm \
             -ti ibmcase-python:test bash \
             -c "cd /refarch-kc/itg-tests/ContainersPython && \

--- a/itg-tests/ContainersPython/addAvroContainerES.sh
+++ b/itg-tests/ContainersPython/addAvroContainerES.sh
@@ -61,7 +61,6 @@ docker run  -e KAFKA_BROKERS=$KAFKA_BROKERS \
             -e DATA_SCHEMAS="/refarch-kc/data_schemas" \
             ${add_cert_to_container_command} \
             -v ${MAIN_DIR}:/refarch-kc \
-            --network=docker_default \
             --rm \
             -ti ibmcase-python:test bash \
             -c "cd /refarch-kc/itg-tests/ContainersPython && \

--- a/itg-tests/ContainersPython/addContainer.sh
+++ b/itg-tests/ContainersPython/addContainer.sh
@@ -43,6 +43,8 @@ source ${MAIN_DIR}/scripts/setenv.sh $kcenv
 
 if [ "OCP" == "${kcenv}" ]; then
     add_cert_to_container_command=" -e PEM_CERT=/certs/${PEM_FILE} -v ${CA_LOCATION}:/certs"
+else 
+    attach_to_network="--network=docker_default"
 fi
 
 # Run the container producer
@@ -53,8 +55,8 @@ docker run  -e KAFKA_BROKERS=$KAFKA_BROKERS \
             -e KAFKA_APIKEY=$KAFKA_APIKEY \
             -e KAFKA_ENV=$KAFKA_ENV \
             ${add_cert_to_container_command} \
+            ${attach_to_network} \
             -v ${MAIN_DIR}:/refarch-kc \
-            --network=docker_default \
             --rm \
             -ti ibmcase-python:test bash \
             -c "cd /refarch-kc/itg-tests/ContainersPython && \

--- a/itg-tests/ContainersPython/getAvroContainer.sh
+++ b/itg-tests/ContainersPython/getAvroContainer.sh
@@ -46,6 +46,7 @@ if [ "OCP" == "${kcenv}" ]; then
     FINAL_SCHEMA_REGISTRY_URL="https://token:${KAFKA_APIKEY}@${END_SCHEMA_REGISTRY_URL}" 
 else
     FINAL_SCHEMA_REGISTRY_URL=${SCHEMA_REGISTRY_URL}
+    attach_to_network="--network=docker_default"
 fi
 
 # Run the container consumer
@@ -58,7 +59,7 @@ docker run  -e KAFKA_BROKERS=$KAFKA_BROKERS \
             -e SCHEMA_REGISTRY_URL=$FINAL_SCHEMA_REGISTRY_URL \
             ${add_cert_to_container_command} \
             -v ${MAIN_DIR}:/refarch-kc \
-            --network=docker_default \
+            ${attach_to_network} \
             --rm \
             -ti ibmcase-python:test bash \
             -c "cd /refarch-kc/itg-tests/ContainersPython \

--- a/itg-tests/ContainersPython/getAvroContainerES.sh
+++ b/itg-tests/ContainersPython/getAvroContainerES.sh
@@ -58,7 +58,6 @@ docker run  -e KAFKA_BROKERS=$KAFKA_BROKERS \
             -e SCHEMA_REGISTRY_URL=$FINAL_SCHEMA_REGISTRY_URL \
             ${add_cert_to_container_command} \
             -v ${MAIN_DIR}:/refarch-kc \
-            --network=docker_default \
             --rm \
             -ti ibmcase-python:test bash \
             -c "cd /refarch-kc/itg-tests/ContainersPython \

--- a/itg-tests/ContainersPython/getContainer.sh
+++ b/itg-tests/ContainersPython/getContainer.sh
@@ -42,6 +42,8 @@ source ${MAIN_DIR}/scripts/setenv.sh $kcenv
 
 if [ "OCP" == "${kcenv}" ]; then
     add_cert_to_container_command=" -e PEM_CERT=/certs/${PEM_FILE} -v ${CA_LOCATION}:/certs"
+else
+    attach_to_network="--network=docker_default"
 fi
 
 # Run the container consumer
@@ -53,7 +55,7 @@ docker run  -e KAFKA_BROKERS=$KAFKA_BROKERS \
             -e KAFKA_ENV=$KAFKA_ENV \
             ${add_cert_to_container_command} \
             -v ${MAIN_DIR}:/refarch-kc \
-            --network=docker_default \
+            ${attach_to_network} \
             --rm \
             -ti ibmcase-python:test bash \
             -c "cd /refarch-kc/itg-tests/ContainersPython && \

--- a/itg-tests/kafka/KcAvroConsumer.py
+++ b/itg-tests/kafka/KcAvroConsumer.py
@@ -28,7 +28,7 @@ class KafkaConsumer:
             options['sasl.mechanisms'] = 'PLAIN'
             options['sasl.username'] = 'token'
             options['sasl.password'] = self.kafka_apikey
-        if (self.kafka_env == 'ICP'):
+        if (self.kafka_env == 'OCP'):
             options['ssl.ca.location'] = os.environ['PEM_CERT']
             options['schema.registry.ssl.ca.location'] = os.environ['PEM_CERT']
         print("This is the configuration for the consumer:")

--- a/itg-tests/kafka/KcAvroConsumerES.py
+++ b/itg-tests/kafka/KcAvroConsumerES.py
@@ -28,7 +28,7 @@ class KafkaConsumer:
             options['sasl.mechanisms'] = 'PLAIN'
             options['sasl.username'] = 'token'
             options['sasl.password'] = self.kafka_apikey
-        if (self.kafka_env == 'ICP'):
+        if (self.kafka_env == 'OCP'):
             options['ssl.ca.location'] = os.environ['PEM_CERT']
             options['schema.registry.ssl.ca.location'] = os.environ['PEM_CERT']
         print("This is the configuration for the consumer:")

--- a/itg-tests/kafka/KcAvroProducer.py
+++ b/itg-tests/kafka/KcAvroProducer.py
@@ -22,7 +22,7 @@ class KafkaProducer:
             options['sasl.mechanisms'] = 'PLAIN'
             options['sasl.username'] = 'token'
             options['sasl.password'] = self.kafka_apikey
-        if (self.kafka_env == 'ICP'):
+        if (self.kafka_env == 'OCP'):
             options['ssl.ca.location'] = os.environ['PEM_CERT']
             options['schema.registry.ssl.ca.location'] = os.environ['PEM_CERT']
         print("--- This is the configuration for the producer: ---")

--- a/itg-tests/kafka/KcAvroProducerES.py
+++ b/itg-tests/kafka/KcAvroProducerES.py
@@ -22,7 +22,7 @@ class KafkaProducer:
             options['sasl.mechanisms'] = 'PLAIN'
             options['sasl.username'] = 'token'
             options['sasl.password'] = self.kafka_apikey
-        if (self.kafka_env == 'ICP'):
+        if (self.kafka_env == 'OCP'):
             options['ssl.ca.location'] = os.environ['PEM_CERT']
             options['schema.registry.ssl.ca.location'] = os.environ['PEM_CERT']
         print("--- This is the configuration for the producer: ---")


### PR DESCRIPTION
Two main changes:

1. Allow some scripts to send messages to OCP by not needing these to be int he network_default docker network that is used to run locally with confluent
2. BUG in some python scripts that were still referencing ICP rather than OCP