### PR TITLE
Fix localk8s scripts to run integration tests against mock BPM

### DIFF
--- a/scripts/localk8s/README.md
+++ b/scripts/localk8s/README.md
@@ -40,9 +40,13 @@ Each of the microservices is then installed using its respective Helm chart. The
 
 ### Integration tests
 
-Running the `run-integration-tests.sh` script will create a Kubernetes job using the `itg-tests/es-it/ReggerItgTests.yaml` definition, with the `KAFKA_ENV` variable set to `LOCAL`, and the topic names set to their default values (without the `itg-` prefix).
-
-It will then follow the log so that the output and progress of the tests can be viewed on the console.
+Running the `run-integration-tests.sh` script will:
+- Update the `kafka-topics` configmap to prefix each Kafka topic with `itg-`,
+- Create the itg-prefixed topics,
+- Restart the microservices so that they pick up the new topic configuration,
+- Create a Kubernetes job using the `itg-tests/es-it/ReeferItgTests.yaml` definition, with the `KAFKA_ENV` variable set to `LOCAL`,
+- Follow the log so that the output and progress of the tests can be viewed on the console,
+- Revert the topic names to their normal values, and restart the microservices.
 
 ## Uninstalling
 

--- a/scripts/localk8s/bpm-configmap.yaml
+++ b/scripts/localk8s/bpm-configmap.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: bpm-anomaly
+data:
+  url: <replace with your BPM workflow endpoint>
+  login: <replace with your BPM authentication endpoint>
+  expiration: <replace with the number of second for the auth token to expire after>
+  anomalyThreshold: <replace with the number of anomaly events to receive before calling BPM>

--- a/scripts/localk8s/bpm-configmap.yaml
+++ b/scripts/localk8s/bpm-configmap.yaml
@@ -3,7 +3,7 @@ kind: ConfigMap
 metadata:
   name: bpm-anomaly
 data:
-  url: <replace with your BPM workflow endpoint>
-  login: <replace with your BPM authentication endpoint>
-  expiration: <replace with the number of second for the auth token to expire after>
-  anomalyThreshold: <replace with the number of anomaly events to receive before calling BPM>
+  url: "my-bpm-endpoint"  # replace with your BPM workflow endpoint
+  login: "user"           # replace with your BPM authentication endpoint
+  expiration: "100"       # replace with the number of second for the auth token to expire after
+  anomalyThreshold: "3"   # replace with the number of anomaly events to receive before calling BPM

--- a/scripts/localk8s/bpm-password.txt
+++ b/scripts/localk8s/bpm-password.txt
@@ -1,0 +1,1 @@
+password='<replace with your BPM password>'

--- a/scripts/localk8s/bpm-username.txt
+++ b/scripts/localk8s/bpm-username.txt
@@ -1,0 +1,1 @@
+user='<replace with your BPM user>'

--- a/scripts/localk8s/install-app.bat
+++ b/scripts/localk8s/install-app.bat
@@ -24,6 +24,11 @@ kubectl create secret generic postgresql-url --from-literal=binding="jdbc:postgr
 kubectl create secret generic postgresql-user --from-literal=binding="postgres" -n shipping
 kubectl create secret generic postgresql-pwd --from-literal=binding="supersecret" -n shipping
 
+:: Create configmap and secret to allow container microservice to connect to BPM
+:: Note: you will need to modify bpm-configmap.yaml, bpm-username.txt and bpm-password.txt appropriately.
+kubectl apply -f %SCRIPTLOC%\bpm-configmap.yaml -n shipping
+kubectl create secret generic bpm-anomaly --from-file=%SCRIPTLOC%\bpm-username.txt --from-file=%SCRIPTLOC%\bpm-password.txt -n shipping
+
 :: Create a configmap to allow microservices to find Kafka
 :: This uses port 9092 (without TLS)
 kubectl create configmap kafka-brokers --from-literal=brokers="my-cluster-kafka-bootstrap.kafka.svc:9092" -n shipping

--- a/scripts/localk8s/install-app.sh
+++ b/scripts/localk8s/install-app.sh
@@ -22,6 +22,11 @@ kubectl create secret generic postgresql-url --from-literal=binding="jdbc:postgr
 kubectl create secret generic postgresql-user --from-literal=binding="postgres" -n shipping
 kubectl create secret generic postgresql-pwd --from-literal=binding="supersecret" -n shipping
 
+# Create configmap and secret to allow container microservice to connect to BPM
+# Note: you will need to modify bpm-configmap.yaml, bpm-username.txt and bpm-password.txt appropriately.
+kubectl apply -f $SCRIPTLOC/bpm-configmap.yaml -n shipping
+kubectl create secret generic bpm-anomaly --from-file=$SCRIPTLOC/bpm-username.txt --from-file=$SCRIPTLOC/bpm-password.txt -n shipping
+
 # Create a configmap to allow microservices to find Kafka
 # This uses port 9092 (without TLS)
 kubectl create configmap kafka-brokers --from-literal=brokers="my-cluster-kafka-bootstrap.kafka.svc:9092" -n shipping

--- a/scripts/localk8s/itg-bpm-configmap.yaml
+++ b/scripts/localk8s/itg-bpm-configmap.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: bpm-anomaly
+data:
+  url: 'http://localhost:8080/bpm_mockup/bpm_process_404'
+  login: 'http://localhost:8080/bpm_mockup/login'
+  expiration: 100
+  anomalyThreshold: 3

--- a/scripts/localk8s/itg-bpm-configmap.yaml
+++ b/scripts/localk8s/itg-bpm-configmap.yaml
@@ -3,7 +3,7 @@ kind: ConfigMap
 metadata:
   name: bpm-anomaly
 data:
-  url: 'http://localhost:8080/bpm_mockup/bpm_process_404'
-  login: 'http://localhost:8080/bpm_mockup/login'
-  expiration: 100
-  anomalyThreshold: 3
+  url: "http://localhost:8080/bpm_mockup/bpm_process_404"
+  login: "http://localhost:8080/bpm_mockup/login"
+  expiration: "100"
+  anomalyThreshold: "3"

--- a/scripts/localk8s/run-integration-tests.bat
+++ b/scripts/localk8s/run-integration-tests.bat
@@ -11,6 +11,9 @@ kubectl delete -f %SCRIPTLOC%\..\..\itg-tests\es-it\ReeferItgTests.yaml -n shipp
 kubectl apply -f %SCRIPTLOC%\itg-kafka-topics-configmap.yaml -n shipping
 kubectl apply -f %SCRIPTLOC%\itg-topics.yaml -n kafka
 
+:: Configure BPM to use mockup instance
+kubectl apply -f %SCRIPTLOC%\itg-bpm-configmap.yaml -n shipping
+
 :: Restart services so that they are configured with the new topic names
 kubectl scale deployment --replicas=0 -n shipping --all
 kubectl scale deployment --replicas=1 -n shipping --all
@@ -36,6 +39,9 @@ kubectl logs job/reefer-itgtests-job -n shipping -f
 
 :: Deploy normal Kafka topics
 kubectl apply -f %SCRIPTLOC%\kafka-topics-configmap.yaml -n shipping
+
+:: Restore BPM config
+kubectl apply -f %SCRIPTLOC%\bpm-configmap.yaml -n shipping
 
 :: Restart services so that they are configured with the new topic names
 kubectl scale deployment --replicas=0 -n shipping --all

--- a/scripts/localk8s/run-integration-tests.sh
+++ b/scripts/localk8s/run-integration-tests.sh
@@ -11,6 +11,9 @@ kubectl delete -f $SCRIPTLOC/../../itg-tests/es-it/ReeferItgTests.yaml -n shippi
 kubectl apply -f $SCRIPTLOC/itg-kafka-topics-configmap.yaml -n shipping
 kubectl apply -f $SCRIPTLOC/itg-topics.yaml -n kafka
 
+# Configure BPM to use mockup instance
+kubectl apply -f $SCRIPTLOC/itg-bpm-configmap.yaml -n shipping
+
 # Restart services so that they are configured with the new topic names
 kubectl scale deployment --replicas=0 -n shipping --all
 kubectl scale deployment --replicas=1 -n shipping --all
@@ -36,6 +39,9 @@ kubectl logs job/reefer-itgtests-job -n shipping -f
 
 # Deploy normal Kafka topics
 kubectl apply -f $SCRIPTLOC/kafka-topics-configmap.yaml -n shipping
+
+# Restore BPM config
+kubectl apply -f $SCRIPTLOC/bpm-configmap.yaml -n shipping
 
 # Restart services so that they are configured with the new topic names
 kubectl scale deployment --replicas=0 -n shipping --all

--- a/scripts/localk8s/uninstall-app.bat
+++ b/scripts/localk8s/uninstall-app.bat
@@ -9,6 +9,9 @@ helm uninstall spring-container-ms -n shipping
 helm uninstall voyages-ms -n shipping
 helm uninstall fleet-ms -n shipping
 
+:: Delete configmap for topic names
+kubectl delete -f %SCRIPTLOC%\kafka-topics-configmap.yaml -n shipping
+
 :: Remove Kafka topics
 kubectl delete -f %SCRIPTLOC%\topics.yaml
 

--- a/scripts/localk8s/uninstall-app.bat
+++ b/scripts/localk8s/uninstall-app.bat
@@ -20,6 +20,10 @@ kubectl delete secret postgresql-url -n shipping
 kubectl delete secret postgresql-user -n shipping
 kubectl delete secret postgresql-pwd -n shipping
 
+:: Delete BPM configmap and secret
+kubectl delete configmap bpm-anomaly -n shipping
+kubectl delete secret bpm-anomaly -n shipping
+
 :: Delete Kafka configmap
 kubectl delete configmap kafka-brokers -n shipping
 

--- a/scripts/localk8s/uninstall-app.sh
+++ b/scripts/localk8s/uninstall-app.sh
@@ -9,6 +9,9 @@ helm uninstall spring-container-ms -n shipping
 helm uninstall voyages-ms -n shipping
 helm uninstall fleet-ms -n shipping
 
+# Delete configmap for topic names
+kubectl delete -f $SCRIPTLOC/kafka-topics-configmap.yaml -n shipping
+
 # Remove Kafka topics
 kubectl delete -f $SCRIPTLOC/topics.yaml
 

--- a/scripts/localk8s/uninstall-app.sh
+++ b/scripts/localk8s/uninstall-app.sh
@@ -20,6 +20,10 @@ kubectl delete secret postgresql-url -n shipping
 kubectl delete secret postgresql-user -n shipping
 kubectl delete secret postgresql-pwd -n shipping
 
+# Delete BPM configmap and secret
+kubectl delete configmap bpm-anomaly -n shipping
+kubectl delete secret bpm-anomaly -n shipping
+
 # Delete Kafka configmap
 kubectl delete configmap kafka-brokers -n shipping
 


### PR DESCRIPTION
Depends on https://github.com/ibm-cloud-architecture/refarch-kc-container-ms/pull/43

This adds the `bpm-anomaly` configmap and secret used by the container ms to contact BPM.  I've left placeholder values in the `bpm-configmap.yaml` as these would need to be customized.

When running the integration tests, the `itg-bpm-configmap.yaml` will be applied to point to the mocked BPM, and the configuration restored afterwards.

I also fixed a couple of review comments from #71.