### PR TITLE
Restore missing BPM docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,23 +37,14 @@ For more information, see the [README for the scripts](./scripts/localk8s/README
 
 ### Building this booklet locally
 
-The content of this repository is written with markdown files, packaged with [MkDocs](https://www.mkdocs.org/) and can be built into a book-readable format by MkDocs build processes.
+The content of this repository is written with markdown files, built with Gatsby.  For more information, see the [README for the docs](./docs/README.md).
 
-1. Install MkDocs locally following the [official documentation instructions](https://www.mkdocs.org/#installation).
-1. Install Material plugin for mkdocs:  `pip install mkdocs-material` 
+1. Install NodeJS (https://nodejs.org/)
 2. `git clone https://github.com/ibm-cloud-architecture/refarch-kc.git` _(or your forked repository if you plan to edit)_
-3. `cd refarch-kc`
-4. `mkdocs serve`
-5. Go to `http://127.0.0.1:8000/` in your browser.
-
-### Building this booklet locally but with docker
-
-In some cases you might not want to alter your Python setup and rather go with a docker image instead. This requires docker is running locally on your computer though.
-
-* docker pull squidfunk/mkdocs-material
-* git clone https://github.com/ibm-cloud-architecture/refarch-eda.git (or your forked repository if you plan to edit)
-* docker run --rm -it -p 8000:8000 -v ${PWD}:/docs squidfunk/mkdocs-material
-* Go to http://127.0.0.1:8000/ in your browser.
+3. `cd refarch-kc/docs`
+4. `npm install`
+5. `npm run dev`
+6. Go to `http://127.0.0.1:8000/` in your browser.
 
 ### Pushing the book to GitHub Pages
 

--- a/docs-gatsby/src/pages/deployments/backing-services.mdx
+++ b/docs-gatsby/src/pages/deployments/backing-services.mdx
@@ -258,3 +258,46 @@ To connect to your database from outside the cluster execute the following comma
     kubectl port-forward --namespace <target namespace> svc/postgre-db-postgresql 5432:5432 &&\
     PGPASSWORD="$POSTGRES_PASSWORD" psql --host 127.0.0.1 -U postgres -p 5432
 ```
+
+## BPM
+
+The containers microservice component of this Reefer Container EDA reference application can be integrated with a BPM process for the the maintenance of the containers. This BPM process will dispatch a field engineer so that the engineer can go to the reefer container to fix it. The process of scheduling an engineer and then completing the work can best be facilitated through a process based, structured workflow. We will be using IBM BPM on Cloud or Cloud Pak for Automation to best demonstrate the workflow. This workflow can be explored in detail [here](https://github.com/ibm-cloud-architecture/refarch-reefer-ml/tree/master/docs/bpm).
+
+In order for the containers microservice to fire the BPM workflow, we need to provide the following information through Kubernetes configMaps and secrets:
+
+1. Provide in a configMap:
+   * the **BPM authentication login endpoint**
+   * the **BPM workflow endpoint**
+   * the **BPM anomaly event threshold**
+   * the **BPM authentication token time expiration**
+
+   ```shell
+   cat <<EOF | kubectl apply -f -
+   apiVersion: v1
+   kind: ConfigMap
+   metadata:
+     name: bpm-anomaly
+   data:
+     url: <replace with your BPM workflow endpoint>
+     login: <replace with your BPM authentication endpoint>
+     expiration: <replace with the number of second for the auth token to expire after>
+     anomalyThreshold: <replace with the number of anomaly events to receive before calling BPM>
+   EOF
+   ```
+
+2. Provide your BPM instance's **credentials** in a secret:
+
+   ```shell
+   kubectl create secret generic bpm-anomaly --from-literal=user='<replace with your BPM user>' --from-literal=password='<replace with your BPM password>' -n <target k8s namespace / ocp project>
+   kubectl describe secrets -n <target k8s namespace / ocp project>
+   ```
+
+**IMPORTANT:** The names for both the secret and configMap (`bpm-anomaly`) is the default the container microservice uses in its [helm chart](https://github.com/ibm-cloud-architecture/refarch-kc-container-ms/tree/master/SpringContainerMS/chart/springcontainerms). Make sure the name for the configMap and secret you create **match** the names you used in the containers microservice's helm chart.
+
+If you do not have access to any BPM instance with this field engineer dispatching workflow, you can bypass the call to BPM by disabling such call in the container microservice component. For doing so, you can use the following container microservice's API endpoints:
+
+1. Enable BPM: [`http://<container_microservice_endpoint>/bpm/enable`](#bpm)
+2. Disable BPM: [`http://<container_microservice_endpoint>/bpm/disable`](#bpm)
+3. BPM status: [`http://<container_microservice_endpoint>/bpm/status`](#bpm)
+
+where `<container_microservice_endpoint>` is the route, ingress or nodeport service you associated to your container microservice component at deployment time.

--- a/docs/src/pages/deployments/backing-services.mdx
+++ b/docs/src/pages/deployments/backing-services.mdx
@@ -258,3 +258,46 @@ To connect to your database from outside the cluster execute the following comma
     kubectl port-forward --namespace <target namespace> svc/postgre-db-postgresql 5432:5432 &&\
     PGPASSWORD="$POSTGRES_PASSWORD" psql --host 127.0.0.1 -U postgres -p 5432
 ```
+
+## BPM
+
+The containers microservice component of this Reefer Container EDA reference application can be integrated with a BPM process for the the maintenance of the containers. This BPM process will dispatch a field engineer so that the engineer can go to the reefer container to fix it. The process of scheduling an engineer and then completing the work can best be facilitated through a process based, structured workflow. We will be using IBM BPM on Cloud or Cloud Pak for Automation to best demonstrate the workflow. This workflow can be explored in detail [here](https://github.com/ibm-cloud-architecture/refarch-reefer-ml/tree/master/docs/bpm).
+
+In order for the containers microservice to fire the BPM workflow, we need to provide the following information through Kubernetes configMaps and secrets:
+
+1. Provide in a configMap:
+   * the **BPM authentication login endpoint**
+   * the **BPM workflow endpoint**
+   * the **BPM anomaly event threshold**
+   * the **BPM authentication token time expiration**
+
+   ```shell
+   cat <<EOF | kubectl apply -f -
+   apiVersion: v1
+   kind: ConfigMap
+   metadata:
+     name: bpm-anomaly
+   data:
+     url: <replace with your BPM workflow endpoint>
+     login: <replace with your BPM authentication endpoint>
+     expiration: <replace with the number of second for the auth token to expire after>
+     anomalyThreshold: <replace with the number of anomaly events to receive before calling BPM>
+   EOF
+   ```
+
+2. Provide your BPM instance's **credentials** in a secret:
+
+   ```shell
+   kubectl create secret generic bpm-anomaly --from-literal=user='<replace with your BPM user>' --from-literal=password='<replace with your BPM password>' -n <target k8s namespace / ocp project>
+   kubectl describe secrets -n <target k8s namespace / ocp project>
+   ```
+
+**IMPORTANT:** The names for both the secret and configMap (`bpm-anomaly`) is the default the container microservice uses in its [helm chart](https://github.com/ibm-cloud-architecture/refarch-kc-container-ms/tree/master/SpringContainerMS/chart/springcontainerms). Make sure the name for the configMap and secret you create **match** the names you used in the containers microservice's helm chart.
+
+If you do not have access to any BPM instance with this field engineer dispatching workflow, you can bypass the call to BPM by disabling such call in the container microservice component. For doing so, you can use the following container microservice's API endpoints:
+
+1. Enable BPM: [`http://<container_microservice_endpoint>/bpm/enable`](#bpm)
+2. Disable BPM: [`http://<container_microservice_endpoint>/bpm/disable`](#bpm)
+3. BPM status: [`http://<container_microservice_endpoint>/bpm/status`](#bpm)
+
+where `<container_microservice_endpoint>` is the route, ingress or nodeport service you associated to your container microservice component at deployment time.


### PR DESCRIPTION
In the conversion between the old and new doc formats, the instructions on creating the BPM configmap went missing - I've copied them back in from `docs-archive`.

I also updated the top-level README instructions for working on the docs as the ones there were (I think) related to the old format.  I left the section on publishing the docs alone, as I'm not sure what updates if any are appropriate there.