### PR TITLE
Update resource names for Apposdy version of order-command-ms

### DIFF
--- a/itg-tests/es-it/ReeferItgTests.yaml
+++ b/itg-tests/es-it/ReeferItgTests.yaml
@@ -161,7 +161,7 @@ spec:
           value: "IBMCLOUD"
         # Order command microservice's service name
         - name: ORDER_CMD_MS
-          value: "order-command-ms-app:9080"
+          value: "order-command-ms:9080"
         # Order query microservice's service name
         - name: ORDER_QUERY_MS
           value: "orderqueryms-service:9080"

--- a/itg-tests/es-it/ReeferItgTests.yaml
+++ b/itg-tests/es-it/ReeferItgTests.yaml
@@ -161,7 +161,7 @@ spec:
           value: "IBMCLOUD"
         # Order command microservice's service name
         - name: ORDER_CMD_MS
-          value: "ordercommandms-service:9080"
+          value: "order-command-ms-app:9080"
         # Order query microservice's service name
         - name: ORDER_QUERY_MS
           value: "orderqueryms-service:9080"

--- a/scripts/localk8s/run-integration-tests.bat
+++ b/scripts/localk8s/run-integration-tests.bat
@@ -22,7 +22,7 @@ kubectl scale deployment --replicas=1 -n shipping --all
 kubectl rollout status -n shipping deployment springcontainerms-deployment
 kubectl rollout status -n shipping deployment fleetms-deployment
 kubectl rollout status -n shipping deployment kc-ui-deployment
-kubectl rollout status -n shipping deployment ordercommandms-deployment
+kubectl rollout status -n shipping deployment order-command-ms
 kubectl rollout status -n shipping deployment orderqueryms-deployment
 kubectl rollout status -n shipping deployment voyagesms-deployment
 
@@ -54,6 +54,6 @@ kubectl scale deployment --replicas=1 -n shipping --all
 kubectl rollout status -n shipping deployment springcontainerms-deployment
 kubectl rollout status -n shipping deployment fleetms-deployment
 kubectl rollout status -n shipping deployment kc-ui-deployment
-kubectl rollout status -n shipping deployment ordercommandms-deployment
+kubectl rollout status -n shipping deployment order-command-ms
 kubectl rollout status -n shipping deployment orderqueryms-deployment
 kubectl rollout status -n shipping deployment voyagesms-deployment

--- a/scripts/localk8s/run-integration-tests.sh
+++ b/scripts/localk8s/run-integration-tests.sh
@@ -22,7 +22,7 @@ kubectl scale deployment --replicas=1 -n shipping --all
 kubectl rollout status -n shipping deployment springcontainerms-deployment
 kubectl rollout status -n shipping deployment fleetms-deployment
 kubectl rollout status -n shipping deployment kc-ui-deployment
-kubectl rollout status -n shipping deployment order-command-ms-app
+kubectl rollout status -n shipping deployment order-command-ms
 kubectl rollout status -n shipping deployment orderqueryms-deployment
 kubectl rollout status -n shipping deployment voyagesms-deployment
 
@@ -54,6 +54,6 @@ kubectl scale deployment --replicas=1 -n shipping --all
 kubectl rollout status -n shipping deployment springcontainerms-deployment
 kubectl rollout status -n shipping deployment fleetms-deployment
 kubectl rollout status -n shipping deployment kc-ui-deployment
-kubectl rollout status -n shipping deployment order-command-ms-app
+kubectl rollout status -n shipping deployment order-command-ms
 kubectl rollout status -n shipping deployment orderqueryms-deployment
 kubectl rollout status -n shipping deployment voyagesms-deployment

--- a/scripts/localk8s/run-integration-tests.sh
+++ b/scripts/localk8s/run-integration-tests.sh
@@ -22,7 +22,7 @@ kubectl scale deployment --replicas=1 -n shipping --all
 kubectl rollout status -n shipping deployment springcontainerms-deployment
 kubectl rollout status -n shipping deployment fleetms-deployment
 kubectl rollout status -n shipping deployment kc-ui-deployment
-kubectl rollout status -n shipping deployment ordercommandms-deployment
+kubectl rollout status -n shipping deployment order-command-ms-app
 kubectl rollout status -n shipping deployment orderqueryms-deployment
 kubectl rollout status -n shipping deployment voyagesms-deployment
 
@@ -54,6 +54,6 @@ kubectl scale deployment --replicas=1 -n shipping --all
 kubectl rollout status -n shipping deployment springcontainerms-deployment
 kubectl rollout status -n shipping deployment fleetms-deployment
 kubectl rollout status -n shipping deployment kc-ui-deployment
-kubectl rollout status -n shipping deployment ordercommandms-deployment
+kubectl rollout status -n shipping deployment order-command-ms-app
 kubectl rollout status -n shipping deployment orderqueryms-deployment
 kubectl rollout status -n shipping deployment voyagesms-deployment


### PR DESCRIPTION
https://github.com/ibm-cloud-architecture/refarch-kc-order-ms/pull/72 converts order-comand-ms to an Appsody project.  As a result of this, the name of the service and deployments resources changes. This PR updates the integration tests to cope with this.  Probably best to merge it at the same time.