### PR TITLE
Update service and deployment names

### DIFF
--- a/itg-tests/es-it/ReeferItgTests.yaml
+++ b/itg-tests/es-it/ReeferItgTests.yaml
@@ -167,10 +167,10 @@ spec:
           value: "order-query-ms:9080"
         # Container microservice's service name
         - name: CONTAINER_SPRING_MS
-          value: "springcontainerms-service:8080"
+          value: "spring-container-ms:8080"
         # Voyage microservice's service name
         - name: VOYAGE_MS
-          value: "voyagesms-service:3000"
+          value: "voyages-ms:3000"
         # Orders topic name
         - name: ITGTESTS_ORDERS_TOPIC
           value: "itg-orders"

--- a/scripts/localk8s/install-app.bat
+++ b/scripts/localk8s/install-app.bat
@@ -55,7 +55,7 @@ helm install order-query-ms %REPOBASE%\refarch-kc-order-ms/order-query-ms/chart/
 
 :: Install spring-container-ms using pre-built image
 :: note: uses postgres secrets defined above
-helm install spring-container-ms %REPOBASE%\refarch-kc-container-ms/SpringContainerMS/chart/springcontainerms -n shipping --set image.repository=ibmcase/kcontainer-spring-container-ms --set eventstreams.enabled=false --set eventstreams.truststoreRequired=false --set serviceAccountName=kcserviceaccount
+helm install spring-container-ms %REPOBASE%\refarch-kc-container-ms/chart/springcontainerms -n shipping --set image.repository=ibmcase/kcontainer-spring-container-ms --set eventstreams.enabled=false --set eventstreams.truststoreRequired=false --set serviceAccountName=kcserviceaccount
 
 :: Install voyages-ms using pre-built image
 helm install voyages-ms %REPOBASE%\refarch-kc-ms/voyages-ms/chart/voyagesms --set image.repository=ibmcase/kcontainer-voyages-ms -n shipping --set eventstreams.enabled=false --set serviceAccountName=kcserviceaccount

--- a/scripts/localk8s/install-app.bat
+++ b/scripts/localk8s/install-app.bat
@@ -46,7 +46,7 @@ kubectl apply -f %SCRIPTLOC%\kafka-topics-configmap.yaml -n shipping
 kubectl apply -f %SCRIPTLOC%\topics.yaml -n kafka
 
 :: Install order-command-ms using pre-built image
-:: note: --set eventstreams.enabled=false and --set eventstreams.truststoreRequired=false 
+:: note: --set eventstreams.enabled=false and --set eventstreams.truststoreRequired=false
 :: for connecting to Kafka rather than Event Streams
 helm install order-command-ms %REPOBASE%\refarch-kc-order-ms/order-command-ms/chart/ordercommandms -n shipping --set image.repository=ibmcase/kcontainer-order-command-ms --set eventstreams.enabled=false --set eventstreams.truststoreRequired=false --set serviceAccountName=kcserviceaccount
 
@@ -67,12 +67,12 @@ helm install fleet-ms %REPOBASE%\refarch-kc-ms/fleet-ms/chart/fleetms --set imag
 helm install kc-ui %REPOBASE%\refarch-kc-ui/chart/kc-ui --set image.repository=ibmcase/kcontainer-ui -n shipping --set eventstreams.enabled=false --set serviceAccountName=kcserviceaccount
 
 :: Wait for all services to start
-kubectl rollout status -n shipping deployment springcontainerms-deployment
-kubectl rollout status -n shipping deployment fleetms-deployment
-kubectl rollout status -n shipping deployment kc-ui-deployment
-kubectl rollout status -n shipping deployment ordercommandms-deployment
-kubectl rollout status -n shipping deployment orderqueryms-deployment
-kubectl rollout status -n shipping deployment voyagesms-deployment
+kubectl rollout status -n shipping deployment spring-container-ms
+kubectl rollout status -n shipping deployment fleet-ms
+kubectl rollout status -n shipping deployment kc-ui
+kubectl rollout status -n shipping deployment order-command-ms
+kubectl rollout status -n shipping deployment order-query-ms
+kubectl rollout status -n shipping deployment voyages-ms
 
 :end
 :: call %SCRIPTLOC%\postinstall.bat

--- a/scripts/localk8s/install-app.sh
+++ b/scripts/localk8s/install-app.sh
@@ -42,7 +42,7 @@ kubectl apply -f $SCRIPTLOC/kafka-topics-configmap.yaml -n shipping
 kubectl apply -f $SCRIPTLOC/topics.yaml -n kafka
 
 # Install order-command-ms using pre-built image
-# note: --set eventstreams.enabled=false and --set eventstreams.truststoreRequired=false 
+# note: --set eventstreams.enabled=false and --set eventstreams.truststoreRequired=false
 # for connecting to Kafka rather than Event Streams
 helm install order-command-ms $REPOBASE/refarch-kc-order-ms/order-command-ms/chart/ordercommandms -n shipping --set image.repository=ibmcase/kcontainer-order-command-ms --set eventstreams.enabled=false --set eventstreams.truststoreRequired=false --set serviceAccountName=kcserviceaccount
 
@@ -63,11 +63,11 @@ helm install fleet-ms $REPOBASE/refarch-kc-ms/fleet-ms/chart/fleetms --set image
 helm install kc-ui $REPOBASE/refarch-kc-ui/chart/kc-ui --set image.repository=ibmcase/kcontainer-ui -n shipping --set eventstreams.enabled=false --set serviceAccountName=kcserviceaccount
 
 # Wait for all services to start
-kubectl rollout status -n shipping deployment springcontainerms-deployment
-kubectl rollout status -n shipping deployment fleetms-deployment
-kubectl rollout status -n shipping deployment kc-ui-deployment
-kubectl rollout status -n shipping deployment ordercommandms-deployment
-kubectl rollout status -n shipping deployment orderqueryms-deployment
-kubectl rollout status -n shipping deployment voyagesms-deployment
+kubectl rollout status -n shipping deployment spring-container-ms
+kubectl rollout status -n shipping deployment fleet-ms
+kubectl rollout status -n shipping deployment kc-ui
+kubectl rollout status -n shipping deployment order-command-ms
+kubectl rollout status -n shipping deployment order-query-ms
+kubectl rollout status -n shipping deployment voyages-ms
 
 # call $SCRIPTLOC/postinstall.sh

--- a/scripts/localk8s/install-app.sh
+++ b/scripts/localk8s/install-app.sh
@@ -51,7 +51,7 @@ helm install order-query-ms $REPOBASE/refarch-kc-order-ms/order-query-ms/chart/o
 
 # Install spring-container-ms using pre-built image
 # note: uses postgres secrets defined above
-helm install spring-container-ms $REPOBASE/refarch-kc-container-ms/SpringContainerMS/chart/springcontainerms -n shipping --set image.repository=ibmcase/kcontainer-spring-container-ms --set eventstreams.enabled=false --set eventstreams.truststoreRequired=false --set serviceAccountName=kcserviceaccount
+helm install spring-container-ms $REPOBASE/refarch-kc-container-ms/chart/springcontainerms -n shipping --set image.repository=ibmcase/kcontainer-spring-container-ms --set eventstreams.enabled=false --set eventstreams.truststoreRequired=false --set serviceAccountName=kcserviceaccount
 
 # Install voyages-ms using pre-built image
 helm install voyages-ms $REPOBASE/refarch-kc-ms/voyages-ms/chart/voyagesms --set image.repository=ibmcase/kcontainer-voyages-ms -n shipping --set eventstreams.enabled=false --set serviceAccountName=kcserviceaccount

--- a/scripts/localk8s/run-integration-tests.bat
+++ b/scripts/localk8s/run-integration-tests.bat
@@ -19,12 +19,12 @@ kubectl scale deployment --replicas=0 -n shipping --all
 kubectl scale deployment --replicas=1 -n shipping --all
 
 :: Wait for services to restart
-kubectl rollout status -n shipping deployment springcontainerms-deployment
-kubectl rollout status -n shipping deployment fleetms-deployment
-kubectl rollout status -n shipping deployment kc-ui-deployment
+kubectl rollout status -n shipping deployment spring-container-ms
+kubectl rollout status -n shipping deployment fleet-ms
+kubectl rollout status -n shipping deployment kc-ui
 kubectl rollout status -n shipping deployment order-command-ms
 kubectl rollout status -n shipping deployment order-query-ms
-kubectl rollout status -n shipping deployment voyagesms-deployment
+kubectl rollout status -n shipping deployment voyages-ms
 
 :: Deploy integration tests job
 sed -e's#value: "IBMCLOUD#value: "LOCAL#' %SCRIPTLOC%\..\..\itg-tests\es-it\ReeferItgTests.yaml > %SCRIPTLOC%\..\..\itg-tests\es-it\ReeferItgTests.yaml.local
@@ -51,9 +51,9 @@ kubectl scale deployment --replicas=0 -n shipping --all
 kubectl scale deployment --replicas=1 -n shipping --all
 
 :: Wait for services to restart
-kubectl rollout status -n shipping deployment springcontainerms-deployment
-kubectl rollout status -n shipping deployment fleetms-deployment
-kubectl rollout status -n shipping deployment kc-ui-deployment
+kubectl rollout status -n shipping deployment spring-container-ms
+kubectl rollout status -n shipping deployment fleet-ms
+kubectl rollout status -n shipping deployment kc-ui
 kubectl rollout status -n shipping deployment order-command-ms
 kubectl rollout status -n shipping deployment order-query-ms
-kubectl rollout status -n shipping deployment voyagesms-deployment
+kubectl rollout status -n shipping deployment voyages-ms

--- a/scripts/localk8s/run-integration-tests.bat
+++ b/scripts/localk8s/run-integration-tests.bat
@@ -15,8 +15,8 @@ kubectl apply -f %SCRIPTLOC%\itg-topics.yaml -n kafka
 kubectl apply -f %SCRIPTLOC%\itg-bpm-configmap.yaml -n shipping
 
 :: Restart services so that they are configured with the new topic names
-kubectl scale deployment --replicas=0 -n shipping --all
-kubectl scale deployment --replicas=1 -n shipping --all
+kubectl scale deployment --replicas=0 -n shipping -l app.kubernetes.io/part-of=refarch-kc
+kubectl scale deployment --replicas=1 -n shipping -l app.kubernetes.io/part-of=refarch-kc
 
 :: Wait for services to restart
 kubectl rollout status -n shipping deployment spring-container-ms
@@ -47,8 +47,8 @@ kubectl apply -f %SCRIPTLOC%\kafka-topics-configmap.yaml -n shipping
 kubectl apply -f %SCRIPTLOC%\bpm-configmap.yaml -n shipping
 
 :: Restart services so that they are configured with the new topic names
-kubectl scale deployment --replicas=0 -n shipping --all
-kubectl scale deployment --replicas=1 -n shipping --all
+kubectl scale deployment --replicas=0 -n shipping -l app.kubernetes.io/part-of=refarch-kc
+kubectl scale deployment --replicas=1 -n shipping -l app.kubernetes.io/part-of=refarch-kc
 
 :: Wait for services to restart
 kubectl rollout status -n shipping deployment spring-container-ms

--- a/scripts/localk8s/run-integration-tests.sh
+++ b/scripts/localk8s/run-integration-tests.sh
@@ -15,8 +15,8 @@ kubectl apply -f $SCRIPTLOC/itg-topics.yaml -n kafka
 kubectl apply -f $SCRIPTLOC/itg-bpm-configmap.yaml -n shipping
 
 # Restart services so that they are configured with the new topic names
-kubectl scale deployment --replicas=0 -n shipping --all
-kubectl scale deployment --replicas=1 -n shipping --all
+kubectl scale deployment --replicas=0 -n shipping -l app.kubernetes.io/part-of=refarch-kc
+kubectl scale deployment --replicas=1 -n shipping -l app.kubernetes.io/part-of=refarch-kc
 
 # Wait for services to restart
 kubectl rollout status -n shipping deployment spring-container-ms
@@ -47,8 +47,8 @@ kubectl apply -f $SCRIPTLOC/kafka-topics-configmap.yaml -n shipping
 kubectl apply -f $SCRIPTLOC/bpm-configmap.yaml -n shipping
 
 # Restart services so that they are configured with the new topic names
-kubectl scale deployment --replicas=0 -n shipping --all
-kubectl scale deployment --replicas=1 -n shipping --all
+kubectl scale deployment --replicas=0 -n shipping -l app.kubernetes.io/part-of=refarch-kc
+kubectl scale deployment --replicas=1 -n shipping -l app.kubernetes.io/part-of=refarch-kc
 
 # Wait for services to restart
 kubectl rollout status -n shipping deployment spring-container-ms

--- a/scripts/localk8s/run-integration-tests.sh
+++ b/scripts/localk8s/run-integration-tests.sh
@@ -19,12 +19,12 @@ kubectl scale deployment --replicas=0 -n shipping --all
 kubectl scale deployment --replicas=1 -n shipping --all
 
 # Wait for services to restart
-kubectl rollout status -n shipping deployment springcontainerms-deployment
-kubectl rollout status -n shipping deployment fleetms-deployment
-kubectl rollout status -n shipping deployment kc-ui-deployment
+kubectl rollout status -n shipping deployment spring-container-ms
+kubectl rollout status -n shipping deployment fleet-ms
+kubectl rollout status -n shipping deployment kc-ui
 kubectl rollout status -n shipping deployment order-command-ms
 kubectl rollout status -n shipping deployment order-query-ms
-kubectl rollout status -n shipping deployment voyagesms-deployment
+kubectl rollout status -n shipping deployment voyages-ms
 
 # Deploy integration tests job
 sed -e's#value: "IBMCLOUD#value: "LOCAL#' $SCRIPTLOC/../../itg-tests/es-it/ReeferItgTests.yaml > $SCRIPTLOC/../../itg-tests/es-it/ReeferItgTests.yaml.local
@@ -51,9 +51,9 @@ kubectl scale deployment --replicas=0 -n shipping --all
 kubectl scale deployment --replicas=1 -n shipping --all
 
 # Wait for services to restart
-kubectl rollout status -n shipping deployment springcontainerms-deployment
-kubectl rollout status -n shipping deployment fleetms-deployment
-kubectl rollout status -n shipping deployment kc-ui-deployment
+kubectl rollout status -n shipping deployment spring-container-ms
+kubectl rollout status -n shipping deployment fleet-ms
+kubectl rollout status -n shipping deployment kc-ui
 kubectl rollout status -n shipping deployment order-command-ms
 kubectl rollout status -n shipping deployment order-query-ms
-kubectl rollout status -n shipping deployment voyagesms-deployment
+kubectl rollout status -n shipping deployment voyages-ms


### PR DESCRIPTION
Update the integration tests and local installation scripts with the updated service and deployment names for each of the microservices, whose names have been updated to match those that Appsody will generate.

Depends on:

- refarch-kc-ms: https://github.com/ibm-cloud-architecture/refarch-kc-ms/pull/52
- refarch-kc-container-ms: https://github.com/ibm-cloud-architecture/refarch-kc-container-ms/pull/51
- refarch-kc-order-ms: https://github.com/ibm-cloud-architecture/refarch-kc-order-ms/pull/74
- refarch-kc-ui: https://github.com/ibm-cloud-architecture/refarch-kc-ui/pull/79

Related (but not a dependency):
- refarch-reefer-ml: https://github.com/ibm-cloud-architecture/refarch-reefer-ml/pull/64