### PR TITLE
appsody adjustments

### DIFF
--- a/docker/kc-development-compose-anomaly.yml
+++ b/docker/kc-development-compose-anomaly.yml
@@ -4,7 +4,7 @@
 version: '3'
 services:
     simulator:
-        image: ibmcase/kcontainer-reefer-ml-flask-simulator:test
+        image: ibmcase/kcontainer-reefer-ml-flask-simulator:latest
         hostname: fleetms
         ports:
             - "8080:8080"
@@ -12,7 +12,7 @@ services:
             KAFKA_BROKERS: ${KAFKA_BROKERS:-kafka:9092}
             TELEMETRY_TOPIC: ${MP_MESSAGING_INCOMING_REEFER_TELEMETRY_TOPIC:-reefer-telemetry}
     springcontainerms:
-        image: ibmcase/kcontainer-spring-container-ms:test
+        image: ibmcase/kcontainer-spring-container-ms:latest
         hostname: springcontainerms
         ports:
             - "12081:8080"
@@ -37,7 +37,7 @@ services:
             # LOGGING_CONTAINER_MS_CONSUMER_CONFIG: ${LOGGING_CONTAINER_MS_CONSUMER_CONFIG:-ERROR}
             # LOGGING_CONTAINER_MS_PRODUCER_CONFIG: ${LOGGING_CONTAINER_MS_PRODUCER_CONFIG:-ERROR}
     scoringmp:
-        image: ibmcase/kcontainer-reefer-ml-scoringmp:test
+        image: ibmcase/kcontainer-reefer-ml-scoringmp:latest
         hostname: scoringmp
         ports:
             - "22080:9080"
@@ -51,3 +51,5 @@ services:
             MP_MESSAGING_INCOMING_REEFER_TELEMETRY_TOPIC: ${MP_MESSAGING_INCOMING_REEFER_TELEMETRY_TOPIC:-reefer-telemetry}
             MP_MESSAGING_OUTGOING_CONTAINERS_TOPIC: ${MP_MESSAGING_OUTGOING_CONTAINERS_TOPIC:-containers}
             MP_MESSAGING_CONNECTOR_LIBERTY_KAFKA_BOOTSTRAP_SERVERS: ${KAFKA_BROKERS:-kafka:9092}
+        volumes:
+            - ${BOOTSTRAP_PROPERTIES_PATH}/bootstrap.properties:/config/bootstrap.properties

--- a/docker/kc-development-compose.yml
+++ b/docker/kc-development-compose.yml
@@ -3,19 +3,18 @@
 
 version: '3'
 services:
-    # Undergoing refactoring
-    # simulator:
-    #     image: ibmcase/kcontainer-fleet-ms:test
-    #     hostname: fleetms
-    #     ports:
-    #         - "9080:9080"
-    #         - "9443:9443"
-    #     environment:
-    #         KAFKA_ENV: ${KAFKA_ENV:-LOCAL}
-    #         KAFKA_BROKERS: ${KAFKA_BROKERS:-kafka:9092}
-    #         KAFKA_APIKEY: ${KAFKA_APIKEY}
+    simulator:
+        image: ibmcase/kcontainer-fleet-ms:latest
+        hostname: fleetms
+        ports:
+            - "9080:9080"
+            - "9443:9443"
+        environment:
+            KAFKA_ENV: ${KAFKA_ENV:-LOCAL}
+            KAFKA_BROKERS: ${KAFKA_BROKERS:-kafka:9092}
+            KAFKA_APIKEY: ${KAFKA_APIKEY}
     web:
-        image: ibmcase/kcontainer-ui:test
+        image: ibmcase/kcontainer-ui:latest
         hostname: kcsolution
         ports:
             - "3010:3010"
@@ -23,12 +22,12 @@ services:
             KAFKA_BROKERS: ${KAFKA_BROKERS:-kafka:9092}
             KAFKA_APIKEY: ${KAFKA_APIKEY}
         depends_on:
-            # - simulator
+            - simulator
             - ordercmd
             - orderquery
             - voyages
     ordercmd:
-        image: ibmcase/kcontainer-order-command-ms:test
+        image: ibmcase/kcontainer-order-command-ms:latest
         hostname: ordercmd
         ports:
             - "10080:9080"
@@ -39,7 +38,7 @@ services:
             KCSOLUTION_ORDERS_TOPIC: ${KCSOLUTION_ORDERS_TOPIC:-orders}
             KCSOLUTION_ERRORS_TOPIC: ${KCSOLUTION_ERRORS_TOPIC:-errors}
     orderquery:
-        image: ibmcase/kcontainer-order-query-ms:test
+        image: ibmcase/kcontainer-order-query-ms:latest
         hostname: orderquery
         ports:
             - "11080:9080"
@@ -50,7 +49,7 @@ services:
             KCSOLUTION_ORDERS_TOPIC: ${KCSOLUTION_ORDERS_TOPIC:-orders}
             KCSOLUTION_CONTAINERS_TOPIC: ${KCSOLUTION_CONTAINERS_TOPIC:-containers}
     voyages:
-        image: ibmcase/kcontainer-voyages-ms:test
+        image: ibmcase/kcontainer-voyages-ms:latest
         hostname: voyages
         ports:
             - "3100:3000"
@@ -59,7 +58,7 @@ services:
             KAFKA_BROKERS: ${KAFKA_BROKERS:-kafka:9092}
             KCSOLUTION_ORDERS_TOPIC: ${KCSOLUTION_ORDERS_TOPIC:-orders}
     springcontainerms:
-        image: ibmcase/kcontainer-spring-container-ms:test
+        image: ibmcase/kcontainer-spring-container-ms:latest
         hostname: springcontainerms
         ports:
             - "12081:8080"

--- a/scripts/local/launch.sh
+++ b/scripts/local/launch.sh
@@ -245,18 +245,15 @@ else
                     exit 1
                 fi
 
-                docker build -f ${MAIN_DIR}/../refarch-reefer-ml/scoring-mp/Dockerfile.multistage -t ibmcase/${microservice}-scoringmp:latest ${MAIN_DIR}/../refarch-reefer-ml/scoring-mp/
-                
-                # Scoring-mp has not yet been appsodyfied
-                # pushd ${MAIN_DIR}/../refarch-reefer-ml/scoring-mp/
-                # appsody build -t ibmcase/${microservice}-scoringmp:latest
+                pushd ${MAIN_DIR}/../refarch-reefer-ml/scoring-mp/
+                appsody build -t ibmcase/${microservice}-scoringmp:latest
                 if [[ $? -ne 0 ]]
                 then 
                     echo -e "\e[31m[ERROR] - A problem occurred building the docker image for ${microservice}-scoringmp\e[0m"
                     exit 1
-                # else
-                #     popd
-                #     echo -e "Done"
+                else
+                    popd
+                    echo -e "Done"
                 fi
 
                 echo -e "\e[1;33mBuilding the ${microservice}-flask-simulator:latest docker image...\e[0m"
@@ -280,6 +277,9 @@ else
         done
 
         echo -e "\e[32mStarting all telemetry microservices\e[39m"
+        # Export the location for the bootstrap.properties file needed as a result of a bug in OpenLiberty
+        # where it does not pick up environment variables
+        export BOOTSTRAP_PROPERTIES_PATH=${MAIN_DIR}/../refarch-reefer-ml/scoring-mp/src/main/liberty/config
         # Launching the solution components in detached mode so that the output is cleaner
         # To see the logs execute either:
         # 1. docker-compose -f ${MAIN_DIR}/docker/kc-solution-compose.yml logs


### PR DESCRIPTION
Following changes to adopt latest appsody work

1. Use `latest` in the docker-compose files since that is what the resulting docker container that appsody builds is tagged with.
2. Stand up `fleet ms` as part of the DEV docker compose now that its been ported to appsody.
3. Build `scoring-mp` using appsody now that its been ported to appsody.
4. Mount `bootstrap.properties` for scoring-mp as this is sth the docker build used to do in order for the scoring-mp to work due to the already known OL bug with environment variables.
